### PR TITLE
Keep cached audio when saving the transcript fails

### DIFF
--- a/OpenAIYouTubeTranscriber.py
+++ b/OpenAIYouTubeTranscriber.py
@@ -2022,6 +2022,9 @@ def _run_pipeline(transcriber, cfg):
             if transcriber.create_and_open_txt(transcribed_text, transcript_name):
                 saved_path = os.path.join(transcriber.TRANSCRIPT_DIR, transcript_name)
                 print(f"Saved transcript to {os.path.abspath(saved_path)}")
+            else:
+                # Nothing was saved, so the audio is still needed for a retry
+                transcription_failed = True
     else:
         print("Skipping transcription.")
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ pip install -r requirements-dev.txt
 Common tasks:
 ```bash
 make lint    # Check for code quality issues
-make format  # Auto-fix formatting
+make test    # Run the self-check suite
 make run     # Run the app
 ```
 


### PR DESCRIPTION
create_and_open_txt returning False left transcription_failed unset, so cleanup deleted the temp audio even though no .txt was written, forcing a re-download (and re-paying for AI enhancement) on retry.

Also drop the stale `make format` reference from README; the target was removed from the Makefile.